### PR TITLE
use authz login on session restore

### DIFF
--- a/js-i2b2/cells/PM/PM_misc.js
+++ b/js-i2b2/cells/PM/PM_misc.js
@@ -77,8 +77,6 @@ i2b2.PM.model.IdleTimer.subscribe("idle", function(){
 				// kumc heron login hack
 				var creds = i2b2.PM.pre_authz();
 				i2b2.PM.authz_login(creds);
-
-				//i2b2.PM.doLogin();
 				i2b2.PM.model.dialogTimeout.hide();
 				i2b2.h.LoadingMask.hide();
 				};														   

--- a/js-i2b2/cells/PM/PM_misc.js
+++ b/js-i2b2/cells/PM/PM_misc.js
@@ -74,7 +74,11 @@ i2b2.PM.model.IdleTimer.subscribe("idle", function(){
 						
 				i2b2.h.LoadingMask.show();
 
-				i2b2.PM.doLogin();
+				// kumc heron login hack
+				var creds = i2b2.PM.pre_authz();
+				i2b2.PM.authz_login(creds);
+
+				//i2b2.PM.doLogin();
 				i2b2.PM.model.dialogTimeout.hide();
 				i2b2.h.LoadingMask.hide();
 				};														   


### PR DESCRIPTION
fixes the session restore dialog.

I've tested 'restore' by hitting restore within five minutes and running a query;
I've tested letting the dialog itself timeout which sends you back to heron.

my editor seems to have added a newline on 201.  are we ok with that?